### PR TITLE
provided public resource option even when a app has APISecretMiddlewa…

### DIFF
--- a/tests/falcon/middlewares/test_client_secret.py
+++ b/tests/falcon/middlewares/test_client_secret.py
@@ -18,10 +18,43 @@ class ResourceWithoutRequireSecret:
         resp.body = 'Pass'
 
 
+class PublicResource:
+    is_api_secret_required = False
+
+    def on_get(self, req, resp):
+        resp.body = 'Hello'
+
+
 @falcon.before(require_secret)
 class Resource:
     def on_get(self, req, resp):
         resp.body = 'Hello'
+
+
+class TestSecretMiddlewareRequirePublicResource(testing.TestCase):
+    def setUp(self):
+        self.auth = APISecretMiddleware(
+            'secret',
+            required=True
+        )
+        self.app = falcon.API(middleware=[self.auth])
+        self.app.add_route(TEST_ROUTE, PublicResource())
+
+    def test_access_without_token(self):
+        response = self.simulate_get(TEST_ROUTE)
+        expect(response.status).to.equal(falcon.HTTP_OK)
+
+    def test_access_with_token(self):
+        response = self.simulate_get(TEST_ROUTE, headers={
+                'Authorization': 'secret'
+            })
+        expect(response.status).to.equal(falcon.HTTP_OK)
+
+    def test_access_with_wrong_token(self):
+        response = self.simulate_get(TEST_ROUTE, headers={
+                'Authorization': 'this-is-not-the-right-token'
+            })
+        expect(response.status).to.equal(falcon.HTTP_OK)
 
 
 class TestSecretMiddlewareRequired(testing.TestCase):

--- a/tests/falcon/middlewares/test_json.py
+++ b/tests/falcon/middlewares/test_json.py
@@ -126,7 +126,7 @@ class JSONMiddlewareTest(testing.TestCase):
         expect(response.status).to.equal(falcon.HTTP_OK)
         expect(response.headers).to.contain('content-type')
         expect(response.headers['content-type']).to.contain('application/json')
-    
+
     def test_post_response_content_type_is_not_application_json_and_contains_other_thing(self):
         payload = {'hello': 'world'}
 

--- a/wizeline/falcon/middlewares/secret.py
+++ b/wizeline/falcon/middlewares/secret.py
@@ -16,6 +16,10 @@ class APISecretMiddleware:
         return req.get_header('Authorization') == self._secret
 
     def process_resource(self, req, resp, resource, params):
+        is_api_secret_required = getattr(resource, 'is_api_secret_required', True)
+        if not is_api_secret_required:
+            return
+
         if self._is_secret_required and not self._has_valid_secret(req):
             raise falcon.HTTPUnauthorized
         req._secret = self._secret


### PR DESCRIPTION
Provided public resource option even when an app has APISecretMiddleware enabled.

When service needs to handle both internal requests (from other micro-services) AND external requests (from frontend which lives in a different server). So the internal API secret is not always required, for example, for the requests from frontend. So I updated the code here to provide the option to disable this API secret check for some endpoints. 