### PR TITLE
Parse requirements by hand

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,16 @@
 import re
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 
 def requirements(filename):
-    reqs = parse_requirements(filename, session=False)
-    return [str(r.req) for r in reqs]
+    with open(filename) as file:
+        return [req for req in map(
+            lambda line: line.strip(),
+            filter(
+                lambda text: not text.startswith('#'),
+                file.readlines()
+            )
+        )]
 
 
 def get_version():


### PR DESCRIPTION
Using `pip.req.parse_requirements` stopped working. This PR replaces it by a custom requirements.txt parsing function

More details: https://github.com/pypa/pip/issues/3240