### PR TITLE
[Fix] Replace pycrypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pluggy==0.4.0
 psycopg2==2.7.1
 py==1.4.33
 pycodestyle==2.3.1
-pycrypto==2.6.1
+pycryptodome==3.6.4
 pyflakes==1.5.0
 PyJWT==1.5.0
 pyparsing==2.2.0

--- a/tests/falcon/middlewares/test_json.py
+++ b/tests/falcon/middlewares/test_json.py
@@ -126,7 +126,7 @@ class JSONMiddlewareTest(testing.TestCase):
         expect(response.status).to.equal(falcon.HTTP_OK)
         expect(response.headers).to.contain('content-type')
         expect(response.headers['content-type']).to.contain('application/json')
-    
+
     def test_post_response_content_type_is_not_application_json_and_contains_other_thing(self):
         payload = {'hello': 'world'}
 


### PR DESCRIPTION
There is a security issue on `pycrypto` dependency. The suggested fix is to replace this library for `pycryptodome`.

![image](https://user-images.githubusercontent.com/1304670/43539179-ff72219c-9578-11e8-9d2b-f14b190b64bb.png)
