### PR TITLE
Add BodyParser Middleware

### DIFF
--- a/tests/falcon/middlewares/test_bodyParser.py
+++ b/tests/falcon/middlewares/test_bodyParser.py
@@ -1,0 +1,205 @@
+import json
+
+import falcon
+from falcon import testing
+from urllib.parse import urlencode
+
+from wizeline.falcon.middlewares.bodyParser import BodyParserMiddleware
+
+from sure import expect
+
+ECHO_ROUTE = '/echo'
+SETTABLE_ROUTE = '/settable'
+DISABLED_ROUTE = '/without-middleware'
+
+
+class EchoResource:
+    def __init__(self):
+        self.last_request = None
+
+    def on_post(self, req, resp):
+        self.last_request = req
+        resp.body = json.dumps(req.json)
+
+    def has_request_included_json(self):
+        if not self.last_request:
+            return False
+        if not hasattr(self.last_request, 'json'):
+            return False
+        return self.last_request.json is not None
+
+    def get_last_request(self):
+        return self.last_request
+
+    def get_requested_json_payload(self):
+        if not self.has_request_included_json():
+            return None
+        return self.last_request.json
+
+
+class SettableResource:
+    def __init__(self):
+        self.text_payload = None
+        self.json_payload = None
+
+    def set_text(self, payload):
+        self.text_payload = payload
+
+    def set_json(self, payload):
+        self.json_payload = payload
+
+    def on_get(self, req, resp):
+        if self.text_payload:
+            resp.body = self.text_payload
+        if self.json_payload:
+            resp.json = self.json_payload
+
+
+class DisabledMiddlewareResource(EchoResource):
+    disable_body_parser_middleware = True
+
+    def on_post(self, req, resp):
+        self.last_request = req
+        resp.body = json.dumps(req.stream.read().decode('utf-8'))
+
+
+class BodyParserMiddlewareTest(testing.TestCase):
+    def setUp(self):
+        self._default_headers = None
+        body_parser_middleware = BodyParserMiddleware()
+        self.app = falcon.API(middleware=[body_parser_middleware])
+        self.app.req_options.auto_parse_form_urlencoded = True
+
+        self.echo_resource = EchoResource()
+        self.settable_resource = SettableResource()
+        self.disabled_resource = DisabledMiddlewareResource()
+
+        self.app.add_route(ECHO_ROUTE, self.echo_resource)
+        self.app.add_route(SETTABLE_ROUTE, self.settable_resource)
+        self.app.add_route(DISABLED_ROUTE, self.disabled_resource)
+
+    def test_post_with_json_payload(self):
+        payload = {'hello': 'world'}
+
+        self.simulate_post(
+            ECHO_ROUTE,
+            body=json.dumps(payload),
+            headers={'content-type': 'application/json'}
+        )
+
+        expect(self.echo_resource.has_request_included_json()).to.be.true
+        expect(self.echo_resource.get_last_request()).to.have.property('json')
+        expect(self.echo_resource.get_requested_json_payload()).to.equal(payload)
+
+    def test_post_with_json_array_payload(self):
+        payload = [{'id': 1, 'name': 'Bot'}]
+
+        self.simulate_post(
+            ECHO_ROUTE,
+            body=json.dumps(payload),
+            headers={'content-type': 'application/json'}
+        )
+
+        expect(self.echo_resource.has_request_included_json()).to.be.true
+        expect(self.echo_resource.get_last_request()).to.have.property('json')
+        expect(self.echo_resource.get_requested_json_payload()).to.equal(payload)
+
+    def test_post_response_content_type_is_application_json(self):
+        payload = {'hello': 'world'}
+
+        response = self.simulate_post(
+            ECHO_ROUTE,
+            body=json.dumps(payload),
+            headers={'content-type': 'application/json'}
+        )
+
+        expect(response.status).to.equal(falcon.HTTP_OK)
+        expect(response.headers).to.contain('content-type')
+        expect(response.headers['content-type']).to.contain('application/json')
+
+    def test_post_response_content_type_is_application_json_and_contains_other_thing(self):
+        payload = {'hello': 'world'}
+
+        response = self.simulate_post(
+            ECHO_ROUTE,
+            body=json.dumps(payload),
+            headers={'content-type': 'application/json; charset=utf-8'}
+        )
+
+        expect(response.status).to.equal(falcon.HTTP_OK)
+        expect(response.headers).to.contain('content-type')
+        expect(response.headers['content-type']).to.contain('application/json')
+
+    def test_post_response_content_type_is_not_application_json_and_contains_other_thing(self):
+        payload = {'hello': 'world'}
+
+        response = self.simulate_post(
+            ECHO_ROUTE,
+            body=json.dumps(payload),
+            headers={'content-type': 'charset=utf-8'}
+        )
+
+        expect(response.status).to.equal(falcon.HTTP_UNSUPPORTED_MEDIA_TYPE)
+        expect(response.headers).to.contain('content-type')
+
+    def test_post_with_urlencoded_payload(self):
+        payload = {'hello': 'world'}
+
+        self.simulate_post(
+            ECHO_ROUTE,
+            body=urlencode(payload),
+            headers={'content-type': 'application/x-www-form-urlencoded'}
+        )
+
+        expect(self.echo_resource.has_request_included_json()).to.be.true
+        expect(self.echo_resource.get_last_request()).to.have.property('json')
+        expect(self.echo_resource.get_requested_json_payload()).to.equal(payload)
+
+    def test_post_with_text_payload(self):
+        payload = 'This is plain text'
+
+        response = self.simulate_post(ECHO_ROUTE, body=payload)
+        expect(response.status).to.equal(falcon.HTTP_UNSUPPORTED_MEDIA_TYPE)
+
+    def test_respond_with_a_json(self):
+        self.settable_resource.set_json({'hello': 'world'})
+
+        response = self.simulate_get(SETTABLE_ROUTE)
+        expect(response.json).to.equal({'hello': 'world'})
+
+    def test_respond_with_none_json(self):
+        self.settable_resource.set_json(None)
+
+        response = self.simulate_get(SETTABLE_ROUTE)
+        expect(response.json).to.equal({})
+
+    def test_respond_with_plain_text(self):
+        self.settable_resource.set_json('This is plain text')
+
+        response = self.simulate_get(SETTABLE_ROUTE)
+        expect(response.status).to.equal(falcon.HTTP_INTERNAL_SERVER_ERROR)
+
+    def test_respond_with_text_and_json(self):
+        self.settable_resource.set_json({'hello': 'world'})
+        self.settable_resource.set_text('This is plain text')
+
+        response = self.simulate_get(SETTABLE_ROUTE)
+        expect(response.text).to.equal('This is plain text')
+
+    def test_respond_with_json_and_empty_text(self):
+        self.settable_resource.set_json({'hello': 'world'})
+        self.settable_resource.set_text('')
+
+        response = self.simulate_get(SETTABLE_ROUTE)
+        expect(response.json).to.equal({'hello': 'world'})
+
+    def test_ignore_middleware(self):
+        payload = {'hello': 'world'}
+
+        self.simulate_post(
+            DISABLED_ROUTE,
+            body=json.dumps(payload)
+        )
+
+        expect(self.disabled_resource.has_request_included_json()).to.be.false
+        expect(self.disabled_resource.get_last_request()).to.not_have.property('json')

--- a/wizeline/falcon/middlewares/bodyParser.py
+++ b/wizeline/falcon/middlewares/bodyParser.py
@@ -1,0 +1,58 @@
+import json
+from json.decoder import JSONDecodeError
+
+import falcon
+
+class BodyParserMiddleware:
+    def process_resource(self, req, resp, resource, params):
+        if self._is_middleware_enabled(resource) and self._request_method_has_payload(req):
+            if self._is_json_content_type(req):
+                try:
+                    req.text = self._get_payload(req)
+
+                    if req.text.strip() != '':
+                        req.json = json.loads(req.text)
+                    else:
+                        req.json = {}
+
+                except JSONDecodeError:
+                    raise falcon.HTTPInternalServerError()
+            elif self._is_urlencoded_content_type(req):
+                req.json = req.params
+            else:
+                raise falcon.HTTPUnsupportedMediaType()
+
+    def _is_middleware_enabled(self, resource):
+        return not hasattr(resource, 'disable_json_middleware') \
+            or not resource.disable_json_middleware
+
+    def _request_method_has_payload(self, req):
+        return req.method in ('POST', 'PUT', 'PATCH')
+
+    def _is_json_content_type(self, req):
+        return req.content_type and \
+               ('application/json' in req.content_type or 'text/json' in req.content_type)
+
+    def _is_urlencoded_content_type(self, req):
+        return req.content_type and ('application/x-www-form-urlencoded' in req.content_type)
+
+    def _get_payload(self, req):
+        return req.bounded_stream.read().decode('utf-8')
+
+    def process_response(self, req, resp, resource, req_succeeded):
+        if not self._has_body(resp):
+            resp.body = self._serialize_json_to_string(resp)
+
+    def _has_body(self, resp):
+        return resp.body is not None
+
+    def _serialize_json_to_string(self, resp):
+        if self._has_json(resp):
+            if not isinstance(resp.json, dict) and \
+               not isinstance(resp.json, list):
+                raise falcon.HTTPInternalServerError()
+            return json.dumps(resp.json)
+        return json.dumps({})
+
+    def _has_json(self, resp):
+        return hasattr(resp, 'json')


### PR DESCRIPTION
A new variation of JSONMiddleware but for different content types.
Now supports:
- `application/json`
- `application/x-www-form-urlencoded`