### PR TITLE
Fix: Return Bad Request when invalid JSON was provided

### DIFF
--- a/tests/falcon/middlewares/test_json.py
+++ b/tests/falcon/middlewares/test_json.py
@@ -146,6 +146,17 @@ class JSONMiddlewareTest(testing.TestCase):
         response = self.simulate_post(ECHO_ROUTE, body=payload)
         expect(response.status).to.equal(falcon.HTTP_UNSUPPORTED_MEDIA_TYPE)
 
+    def test_post_with_invalid_json_payload(self):
+        payload = '{invalid json}'
+
+        response = self.simulate_post(
+            ECHO_ROUTE,
+            body=payload,
+            headers={'content-type': 'application/json'}
+        )
+        expect(response.status).to.equal(falcon.HTTP_BAD_REQUEST)
+        expect(response.text).should_not.be.equal(None)
+
     def test_respond_with_a_json(self):
         self.settable_resource.set_json({'hello': 'world'})
 

--- a/wizeline/falcon/middlewares/json.py
+++ b/wizeline/falcon/middlewares/json.py
@@ -20,9 +20,9 @@ class JSONMiddleware:
                 req.json = (json.loads(req.text, encoding='utf-8')
                             if req.text.strip() != '' else {})
             except JSONDecodeError as error:
-                raise HTTPBadRequest(f'Invalid JSON received: error={error}')
+                raise HTTPBadRequest(f'Invalid JSON received: error={error}, payload={req.text}')
             except Exception as error:
-                raise HTTPInternalServerError(f'Unexpected error: error={error}')
+                raise HTTPInternalServerError(f'Unexpected error: error={error}, payload={req.text}')
 
     def process_response(self, req, resp, resource, req_succeeded):
         if not self._has_body(resp):
@@ -39,8 +39,7 @@ class JSONMiddleware:
         return req.content_type and ('application/json' in req.content_type or 'text/json' in req.content_type)
 
     def _get_payload(self, req):
-        return (req.bounded_stream.read()
-                .decode('utf-8'))
+        return req.bounded_stream.read().decode('utf-8')
 
     def _has_body(self, resp):
         return resp.body is not None

--- a/wizeline/falcon/middlewares/json.py
+++ b/wizeline/falcon/middlewares/json.py
@@ -1,52 +1,54 @@
 import json
-from json.decoder import JSONDecodeError
+from json import JSONDecodeError
 
-import falcon
+from falcon import (
+    HTTPUnsupportedMediaType,
+    HTTPBadRequest,
+    HTTPInternalServerError
+)
 
 
 class JSONMiddleware:
     def process_resource(self, req, resp, resource, params):
-        if self._is_middleware_enabled(resource) and self._request_method_has_payload(req):
-            if not self._is_json_content_type(req):
-                raise falcon.HTTPUnsupportedMediaType()
+        if (self._is_middleware_enabled(resource)
+           and self._has_request_method_payload(req)):
+            if not self._is_content_type_valid(req):
+                raise HTTPUnsupportedMediaType()
 
             try:
                 req.text = self._get_payload(req)
-
-                if req.text.strip() != '':
-                    req.json = json.loads(req.text)
-                else:
-                    req.json = {}
-
-            except JSONDecodeError:
-                raise falcon.HTTPInternalServerError()
-
-    def _is_middleware_enabled(self, resource):
-        return not hasattr(resource, 'disable_json_middleware') \
-            or not resource.disable_json_middleware
-
-    def _request_method_has_payload(self, req):
-        return req.method in ('POST', 'PUT')
-
-    def _is_json_content_type(self, req):
-        return req.content_type and \
-               ('application/json' in req.content_type or 'text/json' in req.content_type)
-
-    def _get_payload(self, req):
-        return req.bounded_stream.read().decode('utf-8')
+                req.json = (json.loads(req.text, encoding='utf-8')
+                            if req.text.strip() != '' else {})
+            except JSONDecodeError as error:
+                raise HTTPBadRequest(f'Invalid JSON received: error={error}')
+            except Exception as error:
+                raise HTTPInternalServerError(f'Unexpected error: error={error}')
 
     def process_response(self, req, resp, resource, req_succeeded):
         if not self._has_body(resp):
             resp.body = self._serialize_json_to_string(resp)
+
+    def _is_middleware_enabled(self, resource):
+        return (not hasattr(resource, 'disable_json_middleware')
+                or not resource.disable_json_middleware)
+
+    def _has_request_method_payload(self, req):
+        return req.method in ('POST', 'PUT')
+
+    def _is_content_type_valid(self, req):
+        return req.content_type and ('application/json' in req.content_type or 'text/json' in req.content_type)
+
+    def _get_payload(self, req):
+        return (req.bounded_stream.read()
+                .decode('utf-8'))
 
     def _has_body(self, resp):
         return resp.body is not None
 
     def _serialize_json_to_string(self, resp):
         if self._has_json(resp):
-            if not isinstance(resp.json, dict) and \
-               not isinstance(resp.json, list):
-                raise falcon.HTTPInternalServerError()
+            if not isinstance(resp.json, (dict, list)):
+                raise HTTPInternalServerError(f'Unexpected error parsing response: payload={resp.json}')
             return json.dumps(resp.json)
         return json.dumps({})
 


### PR DESCRIPTION
Fix the returned HTTP error when an invalid JSON is provided in the body of the request. Before an Internal Server Error was returned, changed to Bad Request.

**Before**:
Request:
```json
{
    "invalid invalid json"
}
```
Response:
```json
status: "500 Internal Server Error"
{
    "title": "500 Internal Server Error"
}
```


**After**:
Request:
```json
{
    "invalid invalid json"
}
```
Response:
```json
status: "400 Bad Request"
{
    "title": "Invalid JSON received: error=Expecting ':' delimiter: line 1 column 24 (char 23), payload={\"invalid invalid json\"}"
}
```